### PR TITLE
Load image into task list once the image has succesfully loaded

### DIFF
--- a/src/bootstrap-waterfall.js
+++ b/src/bootstrap-waterfall.js
@@ -313,9 +313,11 @@
     this.$pins.each(function () {
       var img = new Image()
       img.src = $(this).data('bootstrap-waterfall-src')
-      var pin = new Pin(img)
-      that.tasks.push(pin)
-      $(this).data('bootstrap-waterfall-pin', pin)
+      img.onload = function (evt){
+          var pin = new Pin(this)
+          that.tasks.push(pin)
+          $(this).data('bootstrap-waterfall-pin', pin)
+      }
     })
 
     return this


### PR DESCRIPTION
We noticed a bug that if an image 404s, the entire board breaks at the point of the 404 and will not load beyond that point. 

In order for it not to break the entire board, we wait until the image onload event fires and then add the image to the Loader.tasks queue. 
